### PR TITLE
Fix NodeJS workflow to run lint and tests

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -1,4 +1,4 @@
-name: NodeJS with Gulp
+name: NodeJS CI
 
 on:
   push:
@@ -15,14 +15,19 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
-    - name: Build
-      run: |
-        npm install
-        gulp
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- update the Node.js workflow to install dependencies and run the repository's lint and test scripts instead of invoking gulp
- enable npm caching for the matrix of Node.js versions

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9825f85dc833180ef5cfbf212fa28

## Summary by Sourcery

Update GitHub Actions Node.js workflow to install dependencies, run lint and tests with npm, replace gulp, and enable npm caching

CI:
- Rename workflow to NodeJS CI
- Enable npm caching in setup-node
- Replace gulp invocation with npm install, lint, and test steps